### PR TITLE
Fixed a warning in FeedChannelModel

### DIFF
--- a/src/Resources/contao/models/FeedChannelModel.php
+++ b/src/Resources/contao/models/FeedChannelModel.php
@@ -96,8 +96,10 @@ class FeedChannelModel
             $oRssFeedItem->sGuid = $arSimplePieItems[$i]->get_id();
 
             $arCategories = $arSimplePieItems[$i]->get_categories();
-            for ($j = 0; $j < count($arCategories); $j++) {
-                $oRssFeedItem->arCategoryLabels[$j] = $arCategories[$j]->get_label();
+            if (null !== $arCategories) {
+                for ($j = 0; $j < count($arCategories); $j++) {
+                    $oRssFeedItem->arCategoryLabels[$j] = $arCategories[$j]->get_label();
+                }
             }
 
             $oRssFeedItem->sCopyright = $arSimplePieItems[$i]->get_copyright();


### PR DESCRIPTION
Fixed a warning in FeedChannelModel when no category is returned by `$arSimplePieItems[$i]->get_categories()`.

> Warning: count(): Parameter must be an array or an object that implements Countable

Sorry for the additional merge commit, I overlooked that I made the pull request to my own repo :sweat_smile: 