### PR TITLE
Add blank option for image size

### DIFF
--- a/src/Resources/contao/dca/tl_news_archive.php
+++ b/src/Resources/contao/dca/tl_news_archive.php
@@ -82,6 +82,7 @@ $GLOBALS['TL_DCA']['tl_news_archive']['fields']['rssimp_size'] = array(
         'nospace'    => true,
         'helpwizard' => true,
         'tl_class'   => 'w50',
+        'includeBlankOption' => true,
     ),
     'sql'       => "varchar(64) NOT NULL default ''",
 );


### PR DESCRIPTION
If you configure an archive to import news from an RSS feed, an error will currently occur if you do not set an image size. However, the image size of a news entry should be optional and thus the `includeBlankOption` needs to be active (see [here](https://github.com/contao/contao/blob/9864858d36a8319b68b21d3c0f7b912a9d205fc7/news-bundle/src/Resources/contao/dca/tl_news.php#L308)). This PR adds said option.