### PR TITLE
Add support for non-standard enclosures in Atom feeds

### DIFF
--- a/src/Resources/contao/models/FeedChannelModel.php
+++ b/src/Resources/contao/models/FeedChannelModel.php
@@ -132,6 +132,21 @@ class FeedChannelModel
             $arEnclosures    = $arSimplePieItems[$i]->get_enclosures();
             $aTempEnclosures = array();
 
+            // Process non-standard enclosures
+            if ($enclosure = $arSimplePieItems[$i]->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'enclosure') && !empty($enclosure[0]['attribs']['']['url'])) {
+                $url = $arSimplePieItems[$i]->sanitize($enclosure[0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI, $arSimplePieItems[$i]->get_base($enclosure[0]));
+
+                if (!empty($enclosure[0]['attribs']['']['type'])) {
+                    $type = $arSimplePieItems[$i]->sanitize($enclosure[0]['attribs']['']['type'], SIMPLEPIE_CONSTRUCT_TEXT);
+                }
+
+                if (!empty($enclosure[0]['attribs']['']['length'])) {
+                    $length = ceil($enclosure[0]['attribs']['']['length']);
+                }
+
+                $arEnclosures[] = new \SimplePie_Enclosure($url, $type, $length);
+            }
+
             $imgAlreadySet = false;
             foreach ($arEnclosures as $oEnclosure) {
 

--- a/src/Resources/contao/models/FeedChannelModel.php
+++ b/src/Resources/contao/models/FeedChannelModel.php
@@ -132,7 +132,7 @@ class FeedChannelModel
             $arEnclosures    = $arSimplePieItems[$i]->get_enclosures();
             $aTempEnclosures = array();
 
-            // Process non-standard enclosures
+            // Process non-standard enclosures (see #4)
             if ($enclosure = $arSimplePieItems[$i]->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'enclosure') && !empty($enclosure[0]['attribs']['']['url'])) {
                 $url = $arSimplePieItems[$i]->sanitize($enclosure[0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI, $arSimplePieItems[$i]->get_base($enclosure[0]));
 

--- a/src/Resources/contao/models/FeedChannelModel.php
+++ b/src/Resources/contao/models/FeedChannelModel.php
@@ -133,7 +133,7 @@ class FeedChannelModel
             $aTempEnclosures = array();
 
             // Process non-standard enclosures (see #4)
-            if ($enclosure = $arSimplePieItems[$i]->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'enclosure') && !empty($enclosure[0]['attribs']['']['url'])) {
+            if (($enclosure = $arSimplePieItems[$i]->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'enclosure')) && !empty($enclosure[0]['attribs']['']['url'])) {
                 $url = $arSimplePieItems[$i]->sanitize($enclosure[0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI, $arSimplePieItems[$i]->get_base($enclosure[0]));
 
                 if (!empty($enclosure[0]['attribs']['']['type'])) {


### PR DESCRIPTION
In the wild we have seen Atom feeds that erroneously utilise the `<enclosure>` tag to provide images and enclosures for feed items. This is obviously wrong and therefore SimplePie (correctly) also does not recognize such enclosures - and thus the provided image is not processed by this extension.

But often times you do not have any control over the source and thus are unable change anything about it. This PR would add support for such a non-standard usage of the `<enclosure>` tag within the Atom XML namespace.

Even though RSS can be very messy, I do understand if you do _not_ want to merge this.